### PR TITLE
Respect the passed in action

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -344,12 +344,12 @@
         // that we think would work best for this key
         if (!action) {
             action = _getReverseMap()[key] ? 'keydown' : 'keypress';
-        }
 
-        // modifier keys don't work as expected with keypress,
-        // switch to keydown
-        if (action == 'keypress' && modifiers.length) {
-            action = 'keydown';
+            // modifier keys don't work as expected with keypress,
+            // switch to keydown
+            if (action == 'keypress' && modifiers.length) {
+                action = 'keydown';
+            }
         }
 
         return action;


### PR DESCRIPTION
If the caller specifies an action to use, then respect that choice.
That allows for callers to pick up the keypress events that browsers
sometimes fire even when control keys are in use
